### PR TITLE
feat: add vmTrace support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.7, 3.8, 3.9]
+                python-version: [3.8, 3.9, 3.10]
 
         steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v2
           with:
-              python-version: 3.8
+              python-version: "3.8"
 
         - name: Install Dependencies
           run: pip install .[lint]
@@ -35,7 +35,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v2
           with:
-              python-version: 3.8
+              python-version: "3.8"
 
         - name: Install Dependencies
           run: pip install .[lint,test]  # Might need test deps
@@ -49,7 +49,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.8, 3.9, 3.10]
+                python-version: ["3.8", "3.9", "3.10"]
 
         steps:
         - uses: actions/checkout@v2
@@ -78,7 +78,7 @@ jobs:
 #        - name: Setup Python
 #          uses: actions/setup-python@v2
 #          with:
-#              python-version: 3.8
+#              python-version: "3.8"
 #
 #        - name: Install Dependencies
 #          run: pip install .[test]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: ["3.8", "3.9", "3.10"]
+                python-version: ["3.7", "3.8", "3.9", "3.10"]
 
         steps:
         - uses: actions/checkout@v2

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -91,6 +91,7 @@ class VMTraceFrame(Struct):
     """
     A synthetic trace frame represening the state at a step of execution.
     """
+
     address: str
     pc: int
     op: str
@@ -127,7 +128,7 @@ def to_trace_frames(
             a decoded trace from a `trace_` rpc.
         depth (int):
             a depth of the call being processed. automatically populated.
-        address (str): 
+        address (str):
             the address of the contract being executed. auto populated except the root call.
         copy_memory (bool):
             whether to copy memory when returning trace frames. disable for a speedup when dealing

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -91,7 +91,6 @@ class VMTraceFrame(Struct):
     """
     A synthetic trace frame represening the state at a step of execution.
     """
-
     address: str
     pc: int
     op: str
@@ -124,9 +123,12 @@ def to_trace_frames(
     Can be used as a much faster drop-in replacement for Geth-style traces.
 
     Arguments:
-        trace (VMTrace): a decoded trace from a `trace_` rpc.
-        depth (int): a depth of the call being processed. auto populated.
-        address (str): the address of the contract being executed. auto populated except the root call.
+        trace (VMTrace):
+            a decoded trace from a `trace_` rpc.
+        depth (int):
+            a depth of the call being processed. automatically populated.
+        address (str): 
+            the address of the contract being executed. auto populated except the root call.
         copy_memory (bool):
             whether to copy memory when returning trace frames. disable for a speedup when dealing
             with traces using a large amount of memory. when disabled, `VMTraceFrame.memory` becomes

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterator, List, Optional, Type
 
-from eth.vm.memory import Memory
-from eth.vm.stack import Stack
-from eth_abi import decode_single, encode_single
+from eth.vm.memory import Memory  # type: ignore
+from eth.vm.stack import Stack  # type: ignore
+from eth_abi import decode_single, encode_single  # type: ignore
 from eth_utils import decode_hex, to_checksum_address
 from hexbytes import HexBytes
-from msgspec import Struct
-from msgspec.json import Decoder
+from msgspec import Struct  # type: ignore
+from msgspec.json import Decoder  # type: ignore
 
 # opcodes grouped by the number of items they pop from the stack
 # fmt: off

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -94,7 +94,7 @@ class VMTraceFrame(Struct):
     op: str
     depth: int
     stack: List[int]
-    memory: List[HexBytes]
+    memory: bytes
     storage: Dict[int, int]
 
 
@@ -133,7 +133,7 @@ def to_trace_frames(
             op=op.op,
             depth=depth,
             stack=[val for typ, val in stack.values],
-            memory=[HexBytes(memory.read_bytes(i, 32)) for i in range(0, len(memory), 32)],
+            memory=memory.read_bytes(0, len(memory)),
             storage=storage.copy(),
         )
 

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -118,6 +118,7 @@ def to_trace_frames(
     memory = Memory()
     stack = Stack()
     storage: Dict[int, int] = {}
+    call_address = None
 
     for op in trace.ops:
         if verbose:

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -81,6 +81,10 @@ class RPCResponse(Struct):
     result: RPCTraceResult
 
 
+class RPCListResponse(Struct):
+    result: List[RPCTraceResult]
+
+
 class RPCTraceResult(Struct):
     trace: Optional[List]
     vmTrace: VMTrace
@@ -185,5 +189,11 @@ def to_trace_frames(
             )
 
 
-def from_rpc_response(buffer: bytes) -> VMTrace:
-    return Decoder(RPCResponse, dec_hook=dec_hook).decode(buffer).result.vmTrace
+def from_rpc_response(buffer: bytes, is_list: bool = False) -> Union[VMTrace, List[VMTrace]]:
+    if is_list:
+        return [
+            item.vmTrace
+            for item in Decoder(RPCListResponse, dec_hook=dec_hook).decode(buffer).result
+        ]
+    else:
+        return Decoder(RPCResponse, dec_hook=dec_hook).decode(buffer).result.vmTrace

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -189,7 +189,7 @@ def dec_hook(type: Type, obj: Any) -> Any:
         return HexBytes(obj)
 
 
-def from_rpc_response(buffer: bytes, is_list: bool = False) -> VMTrace:
+def from_rpc_response(buffer: bytes) -> VMTrace:
     return Decoder(RPCResponse, dec_hook=dec_hook).decode(buffer).result.vmTrace
 
 

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -153,7 +153,8 @@ def to_trace_frames(
             if op.ex.mem:
                 memory.write(op.ex.mem.off, len(op.ex.mem.data), op.ex.mem.data)
 
-            if num_pop := POPCODES.get(op.op):
+            num_pop = POPCODES.get(op.op)
+            if num_pop:
                 stack.pop_any(num_pop)
 
             for item in op.ex.push:
@@ -169,7 +170,7 @@ def to_trace_frames(
 
 
 class RPCResponse(Struct):
-    result: RPCTraceResult | List[RPCTraceResult]
+    result: Union[RPCTraceResult, List[RPCTraceResult]]
 
 
 class RPCTraceResult(Struct):
@@ -185,7 +186,7 @@ def dec_hook(type: Type, obj: Any) -> Any:
         return HexBytes(obj)
 
 
-def from_rpc_response(buffer: bytes) -> VMTrace | List[VMTrace]:
+def from_rpc_response(buffer: bytes) -> Union[VMTrace, List[VMTrace]]:
     """
     Decode structured data from a raw `trace_replayTransaction` or `trace_replayBlockTransactions`.
     """

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -12,7 +12,7 @@ from msgspec.json import Decoder
 
 # fmt: off
 # opcodes grouped by the number of items they pop from the stack
-POPCODES = {
+POPS_TO_CODE = {
     1: ["EXTCODEHASH", "ISZERO", "NOT", "BALANCE", "CALLDATALOAD", "EXTCODESIZE", "BLOCKHASH", "POP", "MLOAD", "SLOAD", "JUMP", "SELFDESTRUCT"],  # noqa: E501
     2: ["SHL", "SHR", "SAR", "REVERT", "ADD", "MUL", "SUB", "DIV", "SDIV", "MOD", "SMOD", "EXP", "SIGNEXTEND", "LT", "GT", "SLT", "SGT", "EQ", "AND", "XOR", "OR", "BYTE", "SHA3", "MSTORE", "MSTORE8", "SSTORE", "JUMPI", "LOG0", "RETURN"],  # noqa: E501
     3: ["RETURNDATACOPY", "ADDMOD", "MULMOD", "CALLDATACOPY", "CODECOPY", "CREATE"],
@@ -21,7 +21,7 @@ POPCODES = {
     7: ["CALL", "CALLCODE"]
 }
 # fmt: on
-POPCODES = {op: n for n in POPCODES for op in POPCODES[n]}
+POPCODES = {op: n for n, opcodes in POPS_TO_CODE.items() for op in opcodes}
 POPCODES.update({f"LOG{n}": n + 2 for n in range(1, 5)})
 POPCODES.update({f"SWAP{i}": i + 1 for i in range(1, 17)})
 POPCODES.update({f"DUP{i}": i for i in range(1, 17)})
@@ -43,7 +43,7 @@ class VMOperation(Struct):
     """The program counter."""
     cost: int
     """The gas cost for this instruction."""
-    ex: Optional[VMExecutedOperation]
+    ex: VMExecutedOperation
     """Information concerning the execution of the operation."""
     sub: Optional[VMTrace]
     """Subordinate trace of the CALL/CREATE if applicable."""
@@ -84,7 +84,7 @@ class RPCResponse(Struct):
 
 class RPCTraceResult(Struct):
     trace: Optional[List]
-    vmTrace: Optional[VMTrace]
+    vmTrace: VMTrace
     stateDiff: Optional[Dict]
 
 

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -6,11 +6,12 @@ from eth.vm.memory import Memory  # type: ignore
 from eth.vm.stack import Stack  # type: ignore
 from eth_utils import to_checksum_address
 from hexbytes import HexBytes
+
 try:
     from msgspec import Struct  # type: ignore
     from msgspec.json import Decoder  # type: ignore
 except ImportError as e:
-    raise ImportError('msgspec not found. install it with `pip install msgspec`') from e
+    raise ImportError("msgspec not found. install it with `pip install msgspec`") from e
 
 # opcodes grouped by the number of items they pop from the stack
 # fmt: off

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -10,9 +10,9 @@ from hexbytes import HexBytes
 from msgspec import Struct
 from msgspec.json import Decoder
 
-# fmt: off
 # opcodes grouped by the number of items they pop from the stack
-POPS_TO_CODE = {
+# fmt: off
+POP_OPCODES = {
     1: ["EXTCODEHASH", "ISZERO", "NOT", "BALANCE", "CALLDATALOAD", "EXTCODESIZE", "BLOCKHASH", "POP", "MLOAD", "SLOAD", "JUMP", "SELFDESTRUCT"],  # noqa: E501
     2: ["SHL", "SHR", "SAR", "REVERT", "ADD", "MUL", "SUB", "DIV", "SDIV", "MOD", "SMOD", "EXP", "SIGNEXTEND", "LT", "GT", "SLT", "SGT", "EQ", "AND", "XOR", "OR", "BYTE", "SHA3", "MSTORE", "MSTORE8", "SSTORE", "JUMPI", "LOG0", "RETURN"],  # noqa: E501
     3: ["RETURNDATACOPY", "ADDMOD", "MULMOD", "CALLDATACOPY", "CODECOPY", "CREATE"],
@@ -21,7 +21,7 @@ POPS_TO_CODE = {
     7: ["CALL", "CALLCODE"]
 }
 # fmt: on
-POPCODES = {op: n for n, opcodes in POPS_TO_CODE.items() for op in opcodes}
+POPCODES = {op: n for n, opcodes in POP_OPCODES.items() for op in opcodes}
 POPCODES.update({f"LOG{n}": n + 2 for n in range(1, 5)})
 POPCODES.update({f"SWAP{i}": i + 1 for i in range(1, 17)})
 POPCODES.update({f"DUP{i}": i for i in range(1, 17)})

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -14,7 +14,7 @@ from msgspec.json import Decoder  # type: ignore
 # fmt: off
 POP_OPCODES = {
     1: ["EXTCODEHASH", "ISZERO", "NOT", "BALANCE", "CALLDATALOAD", "EXTCODESIZE", "BLOCKHASH", "POP", "MLOAD", "SLOAD", "JUMP", "SELFDESTRUCT"],  # noqa: E501
-    2: ["SHL", "SHR", "SAR", "REVERT", "ADD", "MUL", "SUB", "DIV", "SDIV", "MOD", "SMOD", "EXP", "SIGNEXTEND", "LT", "GT", "SLT", "SGT", "EQ", "AND", "XOR", "OR", "BYTE", "SHA3", "MSTORE", "MSTORE8", "SSTORE", "JUMPI", "LOG0", "RETURN"],  # noqa: E501
+    2: ["SHL", "SHR", "SAR", "REVERT", "ADD", "MUL", "SUB", "DIV", "SDIV", "MOD", "SMOD", "EXP", "SIGNEXTEND", "LT", "GT", "SLT", "SGT", "EQ", "AND", "XOR", "OR", "BYTE", "SHA3", "MSTORE", "MSTORE8", "SSTORE", "JUMPI", "RETURN"],  # noqa: E501
     3: ["RETURNDATACOPY", "ADDMOD", "MULMOD", "CALLDATACOPY", "CODECOPY", "CREATE"],
     4: ["CREATE2", "EXTCODECOPY"],
     6: ["STATICCALL", "DELEGATECALL"],
@@ -22,7 +22,7 @@ POP_OPCODES = {
 }
 # fmt: on
 POPCODES = {op: n for n, opcodes in POP_OPCODES.items() for op in opcodes}
-POPCODES.update({f"LOG{n}": n + 2 for n in range(1, 5)})
+POPCODES.update({f"LOG{n}": n + 2 for n in range(0, 5)})
 POPCODES.update({f"SWAP{i}": i + 1 for i in range(1, 17)})
 POPCODES.update({f"DUP{i}": i for i in range(1, 17)})
 

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -6,8 +6,11 @@ from eth.vm.memory import Memory  # type: ignore
 from eth.vm.stack import Stack  # type: ignore
 from eth_utils import to_checksum_address
 from hexbytes import HexBytes
-from msgspec import Struct  # type: ignore
-from msgspec.json import Decoder  # type: ignore
+try:
+    from msgspec import Struct  # type: ignore
+    from msgspec.json import Decoder  # type: ignore
+except ImportError as e:
+    raise ImportError('msgspec not found. install it with `pip install msgspec`') from e
 
 # opcodes grouped by the number of items they pop from the stack
 # fmt: off

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List, Optional, Type
+
+from eth.vm.memory import Memory
+from eth.vm.stack import Stack
+from eth_abi import decode_single, encode_single
+from eth_utils import decode_hex, encode_hex, to_checksum_address
+from hexbytes import HexBytes
+from msgspec import Struct
+from msgspec.json import Decoder, Encoder
+
+# fmt: off
+# opcodes grouped by the number of items they pop from the stack
+POPCODES = {
+    1: ["EXTCODEHASH", "ISZERO", "NOT", "BALANCE", "CALLDATALOAD", "EXTCODESIZE", "BLOCKHASH", "POP", "MLOAD", "SLOAD", "JUMP", "SELFDESTRUCT"],  # noqa: E501
+    2: ["SHL", "SHR", "SAR", "REVERT", "ADD", "MUL", "SUB", "DIV", "SDIV", "MOD", "SMOD", "EXP", "SIGNEXTEND", "LT", "GT", "SLT", "SGT", "EQ", "AND", "XOR", "OR", "BYTE", "SHA3", "MSTORE", "MSTORE8", "SSTORE", "JUMPI", "LOG0", "RETURN"],  # noqa: E501
+    3: ["RETURNDATACOPY", "ADDMOD", "MULMOD", "CALLDATACOPY", "CODECOPY", "CREATE"],
+    4: ["CREATE2", "EXTCODECOPY"],
+    6: ["STATICCALL", "DELEGATECALL"],
+    7: ["CALL", "CALLCODE"]
+}
+# fmt: on
+POPCODES = {op: n for n in POPCODES for op in POPCODES[n]}
+POPCODES.update({f"LOG{n}": n + 2 for n in range(1, 5)})
+POPCODES.update({f"SWAP{i}": i + 1 for i in range(1, 17)})
+POPCODES.update({f"DUP{i}": i for i in range(1, 17)})
+
+
+class uint256(int):
+    pass
+
+
+class VMTrace(Struct):
+    code: HexBytes
+    """The code to be executed."""
+    ops: List[VMOperation]
+    """The operations executed."""
+
+
+class VMOperation(Struct):
+    pc: int
+    """The program counter."""
+    cost: int
+    """The gas cost for this instruction."""
+    ex: Optional[VMExecutedOperation]
+    """Information concerning the execution of the operation."""
+    sub: Optional[VMTrace]
+    """Subordinate trace of the CALL/CREATE if applicable."""
+    op: str
+    """Opcode that is being called."""
+    idx: str
+    """Index in the tree."""
+
+
+class VMExecutedOperation(Struct):
+    used: int
+    """The total gas used."""
+    push: List[uint256]
+    """The stack item placed, if any."""
+    mem: Optional[MemoryDiff]
+    """If altered, the memory delta."""
+    store: Optional[StorageDiff]
+    """The altered storage value, if any."""
+
+
+class MemoryDiff(Struct):
+    off: int
+    """Offset into memory the change begins."""
+    data: HexBytes
+    """The changed data."""
+
+
+class StorageDiff(Struct):
+    key: uint256
+    """Which key in storage is changed."""
+    val: uint256
+    """What the value has been changed to."""
+
+
+class VMTraceFrame(Struct):
+    address: str
+    pc: int
+    op: str
+    depth: int
+    stack: List[int]
+    memory: List[int]
+    storage: Dict[int, int]
+
+
+def enc_hook(obj: Any) -> Any:
+    if type is uint256:
+        return hex(obj)
+    if type is HexBytes:
+        return encode_hex(obj)
+
+
+def dec_hook(type: Type, obj: Any) -> Any:
+    if type is uint256:
+        return uint256(obj, 16)
+    if type is HexBytes:
+        return HexBytes(decode_hex(obj))
+
+
+def to_address(value):
+    return to_checksum_address(decode_single("address", encode_single("uint256", value)))
+
+
+def get_trace_frames_from_vmtrace(
+    trace: VMTrace,
+    depth: int = 0,
+    address: str = None,
+) -> Iterator[VMTraceFrame]:
+    memory = Memory()
+    stack = Stack()
+    storage = {}
+
+    for op in trace.ops:
+        if op.op in ["CALL", "DELEGATECALL", "STATICCALL"]:
+            call_address = to_address(stack.values[-2][1])
+
+        if num_pop := POPCODES.get(op.op):
+            stack.pop_ints(num_pop)
+
+        for item in op.ex.push:
+            stack.push_int(item)
+
+        if op.ex.mem:
+            memory.extend(op.ex.mem.off, len(op.ex.mem.data))
+            memory.write(op.ex.mem.off, len(op.ex.mem.data), op.ex.mem.data)
+
+        if op.ex.store:
+            storage[op.ex.store.key] = op.ex.store.val
+
+        yield VMTraceFrame(
+            address=address,
+            pc=op.pc,
+            op=op.op,
+            depth=depth,
+            stack=[val for typ, val in stack.values],
+            memory=[memory.read_bytes(i, 32) for i in range(0, len(memory), 32)],
+            storage=storage.copy(),
+        )
+
+        if op.sub:
+            yield from get_trace_frames_from_vmtrace(op.sub, offset=depth + 1, address=call_address)
+
+
+decoder = Decoder(VMTrace, dec_hook=dec_hook)
+encoder = Encoder(enc_hook=enc_hook)

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,8 @@ setup(
         "pydantic>=1.9.0,<2.0",
         "hexbytes>=0.2.2,<1.0.0",
         "eth-utils>=1.10.0",
-        "msgspec>=0.7.1",
     ],  # NOTE: Add 3rd party libraries here
-    python_requires=">=3.8,<4",
+    python_requires=">=3.7.2,<4",
     extras_require=extras_require,
     py_modules=["evm_trace"],
     license="Apache-2.0",
@@ -76,6 +75,7 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "eth-utils>=1.10.0",
         "msgspec>=0.7.1",
     ],  # NOTE: Add 3rd party libraries here
-    python_requires=">=3.7.2,<4",
+    python_requires=">=3.8,<4",
     extras_require=extras_require,
     py_modules=["evm_trace"],
     license="Apache-2.0",
@@ -76,7 +76,6 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "pydantic>=1.9.0,<2.0",
         "hexbytes>=0.2.2,<1.0.0",
         "eth-utils>=1.10.0",
+        "msgspec>=0.7.1",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7.2,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

add support for `vmTrace` option in parity-style traces. this allows to get very similar data to geth debug traces, but it works an order of magnitude faster with the rpc responses being three orders of magnitude smaller.

### How I did it

unlike geth, which returns the storage and memory at each frame, this format returns incremental changes of which part of memory was overwritten or which items were pushed onto the stack, which is enough for us to recompute and return an iterator with up-to-date values at each frame at >200k frames/second.

i also added a map for opcodes consuming items from stack, since this info is not a part of the incremental updates.

i use py-evm primitives for an evm-compliant stack and memory implementations.

i also added the current contract address to the context of trace frame.

im using [msgspec](https://jcristharif.com/msgspec/) library here instead of pydantic since it's an order of magnitude faster. i suggest we replace pydantic in this package later on since we mostly work with quite heavy responses here.

### How to verify it

i've assembled a demo which can do pairwise comparison with geth here https://gist.github.com/banteg/7e81dea4505ea07d34230001a6868ac4

`evm_trace.vmtrace.to_trace_frames` can be used as a **drop-in replacement for geth traces**, but it's 1-2 orders of magnitude faster.

### References
- https://docs.rs/web3/latest/web3/types/struct.VMTrace.html
- https://www.evm.codes
- https://github.com/ledgerwatch/erigon/blob/devel/core/vm/instructions.go
- https://github.com/ethereumbook/ethereumbook/blob/develop/13evm.asciidoc
- https://medium.com/coinmonks/ethereum-virtual-machine-evm-how-does-it-work-part-2-4198401d2a11
- https://hackernoon.com/getting-deep-into-evm-how-ethereum-works-backstage-ac7efa1f0015
- https://github.com/ledgerwatch/erigon/blob/devel/cmd/rpcdaemon/commands/trace_adhoc.go#L460

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
