### PR TITLE
fix: vmtrace:to_trace_frames address arg default value

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ source venv/bin/activate
 python setup.py install
 
 # install the developer dependencies (-e is interactive mode)
-pip install -e .[dev]
+pip install -e '.[dev]'
 ```
 
 ## Pre-Commit Hooks

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -145,7 +145,7 @@ def to_trace_frames(
             pc=op.pc,
             op=op.op,
             depth=depth,
-            stack=[val for typ, val in stack.values],
+            stack=[val for _, val in stack.values],
             memory=read_memory(0, len(memory)),
             storage=storage.copy(),
         )

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -103,7 +103,7 @@ def to_address(value):
 def to_trace_frames(
     trace: VMTrace,
     depth: int = 1,
-    address: str = None,
+    address: str = "",
     copy_memory: bool = True,
 ) -> Iterator[VMTraceFrame]:
     """
@@ -132,7 +132,7 @@ def to_trace_frames(
     memory = Memory()
     stack = Stack()
     storage: Dict[int, int] = {}
-    call_address = None
+    call_address = ""
     read_memory = memory.read_bytes if copy_memory else memory.read
 
     for op in trace.ops:


### PR DESCRIPTION
### What I did

Changed the default value of `address` arg in `vmtrace:to_trace_frames` from `None` to `''`, since it's a `str` type.

### How I did it

Change `None` to `''`.

### How to verify it

Run `pytest`.

### Checklist

(No need for new tests)

- [x] Passes all linting checks (pre-commit and CI jobs)
- [] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
