### PR TITLE
fix: Add missing py-evm dependency to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pydantic>=1.10.1,<2",
+        "py-evm>=0.6.0a1",
         "hexbytes>=0.2.3,<1",
         "eth-utils>=2",
         "ethpm-types>=0.3.7,<0.4",


### PR DESCRIPTION
### What I did
Currently the tests fail due to a missing module py-evm. 
```
vmtrace (unittest.loader._FailedTest) ... ERROR

======================================================================
ERROR: vmtrace (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: vmtrace
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/Users/alan/Code/evm-trace/evm_trace/vmtrace.py", line 5, in <module>
    from eth.vm.memory import Memory  # type: ignore
ModuleNotFoundError: No module named 'eth'


----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)
Test failed: <unittest.runner.TextTestResult run=1 errors=1 failures=0>
error: Test failed: <unittest.runner.TextTestResult run=1 errors=1 failures=0>
```

This PR adds `py-evm` to the dependencies and now the tests pass.
### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
