### PR TITLE
fix: issue where could not set returndata in root kwargs

### DIFF
--- a/evm_trace/base.py
+++ b/evm_trace/base.py
@@ -158,7 +158,7 @@ def _create_node_from_call(
             # TODO: Handle "execution halted" vs. gas limit reached
             break
 
-        elif frame.op in ("RETURN", "REVERT"):
+        elif frame.op in ("RETURN", "REVERT") and not node.returndata:
             node.returndata = _extract_memory(
                 offset=frame.stack[-1], size=frame.stack[-2], memory=frame.memory
             )

--- a/tests/test_trace_frame.py
+++ b/tests/test_trace_frame.py
@@ -1,7 +1,9 @@
 import pytest
+from hexbytes import HexBytes
 from pydantic import ValidationError
 
-from evm_trace.base import TraceFrame
+from evm_trace import CallType
+from evm_trace.base import TraceFrame, get_calltree_from_geth_trace
 
 
 def test_trace_frame_validation_passes(trace_frame_data):
@@ -10,8 +12,19 @@ def test_trace_frame_validation_passes(trace_frame_data):
 
 
 def test_trace_no_memory():
-    raw_frame = {"pc": 0, "op": "PUSH1", "gas": 4732305, "gasCost": 3, "depth": 1, "stack": []}
-    assert TraceFrame(**raw_frame)
+    pc = 0
+    op = "REVERT"
+    gas = 4732305
+    gas_cost = 3
+    depth = 1
+    stack = []
+    trace_frame = TraceFrame(pc=pc, op=op, gas=gas, gasCost=gas_cost, depth=depth, stack=stack)
+    assert trace_frame.pc == pc
+    assert trace_frame.op == op
+    assert trace_frame.gas == gas
+    assert trace_frame.gas_cost == gas_cost
+    assert trace_frame.depth == depth
+    assert trace_frame.stack == []
 
 
 @pytest.mark.parametrize(
@@ -26,3 +39,23 @@ def test_trace_frame_validation_fails(test_data, trace_frame_data):
     data = {**trace_frame_data, **test_data}
     with pytest.raises(ValidationError):
         TraceFrame(**data)
+
+
+def test_get_calltree_from_geth_trace(trace_frame_data):
+    trace_frame_data["op"] = "RETURN"
+    returndata = HexBytes("0x0000000000000000000000004d4d2c55eae97a04acafb66011df29463b665732")
+    root_node_kwargs = {
+        "gas_cost": 123,
+        "gas_limit": 1234,
+        "address": "0x56764a0000000000000000000000000000000031",
+        "calldata": HexBytes("0x21325"),
+        "value": 34,
+        "call_type": CallType.CALL,
+        "failed": False,
+        "returndata": returndata,
+    }
+    frames = (TraceFrame(**d) for d in (trace_frame_data,))
+    actual = get_calltree_from_geth_trace(frames, **root_node_kwargs)
+
+    # Tests against a bug where we could not set the return data.
+    assert actual.returndata == returndata


### PR DESCRIPTION
### What I did

For call traces (not transactions), the returndata in root is set a little different, but it was not letting me set it, so this PR changes the condition to only set the returndata from the frames if it not already set. This is also possibly an optimizations for other situations when the returndata is known ahead of time.

### How I did it

adjust `if` condition to also check that it is not already set (from `**root_node_kwargs`)

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
