### PR TITLE
catch exception in normalization

### DIFF
--- a/evm_trace/display.py
+++ b/evm_trace/display.py
@@ -39,6 +39,8 @@ class TreeRepresentation(object):
             address = to_checksum_address(address_hex_str) if address_hex_str else None
         except ImportError:
             # Ignore checksumming if user does not have eth-hash backend installed.
+        except ValueError:
+            # a contract may attempt to call into an address that can't be normalized
             address = address_hex_str  # type: ignore
 
         cost = self.call.gas_cost


### PR DESCRIPTION
Fixes #27 by catching the `ValueError`.