### PR TITLE
fix: allow `merge_reports` to work with single report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,16 +1,17 @@
 ---
 name: Bug report
 about: Report an error that you've encountered.
-labels: 'bug'
+labels: bug
 ---
+
 ### Environment information
 
-* Python Version: x.x.x
-* OS: macOS/linux/win
+- Python Version: x.x.x
+- OS: macOS/linux/win
 
 If using with `ape`, please provide:
 
-* `ape` and plugin versions:
+- `ape` and plugin versions:
 
 ```
 $ ape --version
@@ -24,9 +25,9 @@ $ ape plugins list
 
 Please include information like:
 
-* what command you ran
-* the code that caused the failure (see [this link](https://help.github.com/articles/basic-writing-and-formatting-syntax/) for help with formatting code)
-* full output of the error you received
+- what command you ran
+- the code that caused the failure (see [this link](https://help.github.com/articles/basic-writing-and-formatting-syntax/) for help with formatting code)
+- full output of the error you received
 
 ### How can it be fixed?
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,15 +1,15 @@
 ---
 name: Feature request
 about: Request a new feature, or an improvement to existing functionality.
-labels: 'enhancement'
+labels: enhancement
 ---
 
 ### Overview
 
 Provide a simple overview of what you wish to see added. Please include:
 
-* What you are trying to do
-* Why Ape's current functionality is inadequate to address your goal
+- What you are trying to do
+- Why Ape's current functionality is inadequate to address your goal
 
 ### Specification
 

--- a/.github/ISSUE_TEMPLATE/work-item.md
+++ b/.github/ISSUE_TEMPLATE/work-item.md
@@ -1,14 +1,15 @@
 ---
 name: Work item
 about: New work item for Ape team
-labels: 'backlog'
-
+labels: backlog
 ---
 
 ### Elevator pitch:
+
 <!-- 1-2 line summary of the scope of this work item -->
 
 ### Value:
+
 <!--
   Who is this for?
   Persona or group of people whom will derive value from the scenario.
@@ -16,26 +17,32 @@ labels: 'backlog'
 -->
 
 ### Dependencies:
+
 <!-- Call out key people, teams, tech dependencies, or assumptions. -->
 
 ### Design approach:
+
 <!--
   Free text / diagram / whiteboard picture / etc. that clearly shows your approach and considerations to build the task list.
   Existing code patterns in production code base that you will base your work off of.
 -->
 
 ### Task list:
+
 <!-- Bulleted list describing the exit criteria, desired end state and any documentation, monitors, work for DRI, etc. that will need to be added to make sure someone else can support once it's live. -->
-* [ ] Tasks go here
+
+- [ ] Tasks go here
 
 ### Estimated completion date:
 
-
 ### Design review:
+
 <!-- 1-2 people needed for signoff -->
+
 Do not signoff unless:
-- 1) agreed the tasks and design approach will achieve acceptance, and
-- 2) the work can be completed by one person within the SLA.
-Design reviewers should consider simpler approaches to achieve goals.
+
+- 1. agreed the tasks and design approach will achieve acceptance, and
+- 2. the work can be completed by one person within the SLA.
+     Design reviewers should consider simpler approaches to achieve goals.
 
 (Please leave a comment to sign off)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 ### What I did
 
 <!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
+
 fixes: #
 
 ### How I did it

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -9,12 +9,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
               fetch-depth: 0
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: 3.8
 

--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -12,10 +12,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: 3.8
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,15 +2,22 @@ on: ["push", "pull_request"]
 
 name: Test
 
+concurrency:
+  # Cancel older, in-progress jobs from the same PR, same workflow.
+  # use run_id if the job is triggered by a push to ensure
+  # push-triggered jobs to not get canceled.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
     linting:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: 3.8
 
@@ -22,20 +29,23 @@ jobs:
         - name: Run Black
           run: black --check .
 
+        - name: Run isort
+          run: isort --check-only .
+
         - name: Run flake8
           run: flake8 .
 
-        - name: Run isort
-          run: isort --check-only .
+        - name: Run mdformat
+          run: mdformat . --check
 
     type-check:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: 3.8
 
@@ -56,10 +66,10 @@ jobs:
                 python-version: [3.8, 3.9, "3.10"]
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: ${{ matrix.python-version }}
 

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,1 @@
+number = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,11 @@ repos:
     -   id: mypy
         additional_dependencies: [types-PyYAML, types-requests, types-setuptools]
 
+-   repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.14
+    hooks:
+    -   id: mdformat
+        additional_dependencies: [mdformat-gfm, mdformat-frontmatter]
 
 default_language_version:
     python: python3

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ethereum Virtual Machine transaction tracing tool
 
 ## Dependencies
 
-* [python3](https://www.python.org/downloads) version 3.8 or greater, python3-dev
+- [python3](https://www.python.org/downloads) version 3.8 or greater, python3-dev
 
 ## Installation
 

--- a/evm_trace/gas.py
+++ b/evm_trace/gas.py
@@ -27,7 +27,7 @@ def get_gas_report(calltree: CallTreeNode) -> GasReport:
 def merge_reports(*reports: GasReport) -> GasReport:
     """
     Merge method for merging a list of gas reports and combining a list of gas costs.
-    If given a single report, it does nothing and returns in.
+    If given a single report, it only returns it.
     """
     reports_ls = list(reports)
     if len(reports_ls) == 1:

--- a/evm_trace/gas.py
+++ b/evm_trace/gas.py
@@ -29,16 +29,10 @@ def merge_reports(*reports: GasReport) -> GasReport:
     Merge method for merging a list of gas reports and combining a list of gas costs.
     """
     reports_ls = list(reports)
-    if len(reports_ls) < 1:
-        raise ValueError("Must be 2 or more reports to merge")
-    elif len(reports_ls) == 1:
+    if len(reports_ls) == 1:
         return reports_ls[0]
 
     merged_report: GasReport = copy.deepcopy(reports_ls.pop(0))
-
-    if len(reports_ls) < 1:
-        return merged_report
-
     for report in reports_ls:
         for outer_key, inner_dict in report.items():
             if outer_key not in merged_report:

--- a/evm_trace/gas.py
+++ b/evm_trace/gas.py
@@ -27,6 +27,7 @@ def get_gas_report(calltree: CallTreeNode) -> GasReport:
 def merge_reports(*reports: GasReport) -> GasReport:
     """
     Merge method for merging a list of gas reports and combining a list of gas costs.
+    If given a single report, it does nothing and returns in.
     """
     reports_ls = list(reports)
     if len(reports_ls) == 1:

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ extras_require = {
         "types-setuptools",  # Needed due to mypy typeshed
         "flake8>=5.0.4",  # Style linter
         "isort>=5.10.1",  # Import sorting linter
+        "mdformat>=0.7.16",  # Auto-formatter for markdown
+        "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
+        "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -38,10 +38,16 @@ def test_get_gas_report(call_tree_data):
     assert_all(tree)
 
 
-def test_merged_reports():
+def test_merge_reports():
     merged = merge_reports(*reports)
     assert merged == {
         CONTRACT_A: {METHOD_A: [100, 101, 100, 102, 105, 106]},
         CONTRACT_B: {METHOD_A: [200, 201], METHOD_B: [200, 202, 202, 200, 200]},
         CONTRACT_C: {METHOD_C: [300]},
     }
+
+
+def test_merge_single_report():
+    actual = merge_reports(reports[0])
+    expected = reports[0]
+    assert actual == expected


### PR DESCRIPTION
### What I did

Issue where had to have custom method for handling reports for when there was a single report.

### How I did it

Delete 2 identical, unneeded checks.

### How to verify it

Can call `merge_reports` with single report.
I added a test!

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
