### PR TITLE
fix: general improvements [APE-647]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
             pip install .[lint]
 
         - name: Run Black
-          run: black --check .
+          run: black --check . --diff
 
         - name: Run isort
           run: isort --check-only .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         name: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         name: black

--- a/evm_trace/enums.py
+++ b/evm_trace/enums.py
@@ -4,8 +4,12 @@ from enum import Enum
 class CallType(Enum):
     INTERNAL = "INTERNAL"  # Non-opcode internal call
     CREATE = "CREATE"
+    CREATE2 = "CREATE2"
     CALL = "CALL"
     DELEGATECALL = "DELEGATECALL"
     STATICCALL = "STATICCALL"
     CALLCODE = "CALLCODE"
     SELFDESTRUCT = "SELFDESTRUCT"
+
+
+CALL_OPCODES = (CallType.CALL, CallType.CALLCODE, CallType.DELEGATECALL, CallType.STATICCALL)

--- a/evm_trace/gas.py
+++ b/evm_trace/gas.py
@@ -30,7 +30,11 @@ def merge_reports(*reports: GasReport) -> GasReport:
     If given a single report, it only returns it.
     """
     reports_ls = list(reports)
-    if len(reports_ls) == 1:
+    num_reports = len(reports_ls)
+    if num_reports == 0:
+        return {}
+
+    elif num_reports == 1:
         return reports_ls[0]
 
     merged_report: GasReport = copy.deepcopy(reports_ls.pop(0))

--- a/evm_trace/geth.py
+++ b/evm_trace/geth.py
@@ -143,7 +143,6 @@ def _create_node_from_call(
     node = CallTreeNode(**node_kwargs)
     for frame in trace:
         if frame.op in [x.value for x in CALL_OPCODES]:
-
             # NOTE: Because of the different meanings in structLog style gas values,
             # gas is not set for nodes created this way.
             child_node_kwargs = {"address": frame.stack[-2][-20:], "depth": frame.depth}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
         "eth-hash[pysha3]",  # For eth-utils address checksumming
     ],
     "lint": [
-        "black>=22.12.0",  # auto-formatter and linter
+        "black>=23.1.0",  # auto-formatter and linter
         "mypy>=0.991",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
         "flake8>=5.0.4",  # Style linter

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
         "eth-hash[pysha3]",  # For eth-utils address checksumming
     ],
     "lint": [
-        "black>=22.10.0",  # auto-formatter and linter
+        "black>=22.12.0",  # auto-formatter and linter
         "mypy>=0.991",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
         "flake8>=5.0.4",  # Style linter

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -51,3 +51,7 @@ def test_merge_single_report():
     actual = merge_reports(reports[0])
     expected = reports[0]
     assert actual == expected
+
+
+def test_merge_no_reports():
+    assert merge_reports() == {}


### PR DESCRIPTION
### What I did

* Support `merge_reports` handling 0 reports.. This can help clean up some Ape core code.
* Add `CREATE2` as a `CallType` - noticed it here: https://github.com/Ackee-Blockchain/woke/blob/main/woke/testing/call_trace.py#L39
* Pull out constant tuple `CALL_OPCODES`... This helps downstream usage of this library.
* Include `CALLCODE` as a handled `CallType`.. Seems like it is handled same as `STATICCALL` (https://github.com/Ackee-Blockchain/woke/blob/main/woke/testing/call_trace.py#L335)

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
