### PR TITLE
feat: allow getting contract address on certain TraceFrames

### DIFF
--- a/evm_trace/enums.py
+++ b/evm_trace/enums.py
@@ -11,5 +11,8 @@ class CallType(Enum):
     CALLCODE = "CALLCODE"
     SELFDESTRUCT = "SELFDESTRUCT"
 
+    def __eq__(self, other):
+        return self.value == getattr(other, "value", other)
+
 
 CALL_OPCODES = (CallType.CALL, CallType.CALLCODE, CallType.DELEGATECALL, CallType.STATICCALL)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,32 @@ TRACE_FRAME_DATA = {
         "aadb61a4b4c5d48b7a5669391b7c73852a3ab7795f24721b9a439220b54b591b": "0000000000000000000000000000000000000000000000000000000000000001",  # noqa: E501
     },
 }
+CALL_FRAME_DATA = {
+    "pc": 359,
+    "op": "CALL",
+    "gas": 29971782,
+    "gasCost": 22369,
+    "depth": 1,
+    "stack": [
+        "0xf552a8b8",
+        "0x274b028b03a250ca03644e6c578d81f019ee1323",
+        "0x00",
+        "0x60",
+        "0x24",
+        "0x7c",
+        "0x00",
+        "0x274b028b03a250ca03644e6c578d81f019ee1323",
+        "0x01c95546",
+    ],
+    "memory": [
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x000000000000000000000000000000000000000000000000000000004420e486",
+        "0x0000000000000000000000001e59ce931b4cfea3fe4b875411e280e173cb7a9c",
+    ],
+    "storage": {},
+}
 MUTABLE_CALL_TREE_DATA = {
     "call_type": CallType.CALL,
     "address": HexBytes("0xf2df0b975c0c9efa2f8ca0491c2d1685104d2488"),
@@ -391,6 +417,11 @@ CALL_TREE_DATA_MAP = {
 @pytest.fixture(scope="session")
 def trace_frame_data():
     return TRACE_FRAME_DATA
+
+
+@pytest.fixture(scope="session")
+def call_frame_data():
+    return CALL_FRAME_DATA
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,10 @@
+import pytest
+
+from evm_trace import CallType
+
+
+class TestCallType:
+    @pytest.mark.parametrize("val", (CallType.CALL, "CALL"))
+    def test_eq(self, val):
+        call_type = CallType.CALL
+        assert call_type == val

--- a/tests/test_geth.py
+++ b/tests/test_geth.py
@@ -43,6 +43,10 @@ class TestTraceFrame:
         with pytest.raises(ValidationError):
             TraceFrame(**data)
 
+    def test_address(self, call_frame_data):
+        frame = TraceFrame(**call_frame_data)
+        assert frame.address == HexBytes("0x274b028b03a250ca03644e6c578d81f019ee1323")
+
 
 def test_get_calltree_from_geth_trace(trace_frame_data):
     trace_frame_data["op"] = "RETURN"


### PR DESCRIPTION
### What I did

For any trace frame that has an op in the call opcodes, allow fetching its contract address.
This is particularly helpful in trying to fix a dev message bug I am working on currently.
This also simplifies some of the stuff in the coverage work I have been doing.

### How I did it

* allow eq to check with raw ops
* make calculated property for contract address on trace frame class
** ensure is a call op
** return the calculated address
* replace use elsewhere with it so verify it works

### How to verify it

get a CALL frame and do:

```python
frame.contract_address
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
