### PR TITLE
fix: add keccak256 as alias for sha3 opcode [APE-1262]

### DIFF
--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -14,7 +14,7 @@ from evm_trace.utils import to_address
 # fmt: off
 POP_OPCODES = {
     1: ["EXTCODEHASH", "ISZERO", "NOT", "BALANCE", "CALLDATALOAD", "EXTCODESIZE", "BLOCKHASH", "POP", "MLOAD", "SLOAD", "JUMP", "SELFDESTRUCT"],  # noqa: E501
-    2: ["SHL", "SHR", "SAR", "REVERT", "ADD", "MUL", "SUB", "DIV", "SDIV", "MOD", "SMOD", "EXP", "SIGNEXTEND", "LT", "GT", "SLT", "SGT", "EQ", "AND", "XOR", "OR", "BYTE", "SHA3", "MSTORE", "MSTORE8", "SSTORE", "JUMPI", "RETURN"],  # noqa: E501
+    2: ["SHL", "SHR", "SAR", "REVERT", "ADD", "MUL", "SUB", "DIV", "SDIV", "MOD", "SMOD", "EXP", "SIGNEXTEND", "LT", "GT", "SLT", "SGT", "EQ", "AND", "XOR", "OR", "BYTE", "SHA3", "KECCAK256", "MSTORE", "MSTORE8", "SSTORE", "JUMPI", "RETURN"],  # noqa: E501
     3: ["RETURNDATACOPY", "ADDMOD", "MULMOD", "CALLDATACOPY", "CODECOPY", "CREATE"],
     4: ["CREATE2", "EXTCODECOPY"],
     6: ["STATICCALL", "DELEGATECALL"],


### PR DESCRIPTION
### What I did

`sha3` opcode was renamed to `keccak256` in geth, and it got it renamed in erigon vmtrace output
https://github.com/ethereum/go-ethereum/pull/23976
https://github.com/ledgerwatch/erigon/pull/5890

### How I did it
add `keccak256` as alias for `sha3` opcode

### How to verify it
vm tracing is broken in erigon post shanghai, but you can try [with this patch of mine](https://github.com/ledgerwatch/erigon/pull/7970).

as for reth, you can [track vmtrace compatibility here](https://github.com/paradigmxyz/reth/issues/4071), but it seems far from usable.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
