### PR TITLE
feat: create trace frames function [APE-1336]

### DIFF
--- a/evm_trace/__init__.py
+++ b/evm_trace/__init__.py
@@ -1,11 +1,17 @@
 from .base import CallTreeNode
 from .enums import CallType
-from .geth import TraceFrame, get_calltree_from_geth_call_trace, get_calltree_from_geth_trace
+from .geth import (
+    TraceFrame,
+    create_trace_frames,
+    get_calltree_from_geth_call_trace,
+    get_calltree_from_geth_trace,
+)
 from .parity import ParityTrace, ParityTraceList, get_calltree_from_parity_trace
 
 __all__ = [
     "CallTreeNode",
     "CallType",
+    "create_trace_frames",
     "get_calltree_from_geth_trace",
     "get_calltree_from_geth_call_trace",
     "get_calltree_from_parity_trace",

--- a/evm_trace/geth.py
+++ b/evm_trace/geth.py
@@ -1,5 +1,4 @@
 import math
-from functools import cached_property
 from typing import Dict, Iterator, List, Optional
 
 from eth_utils import to_int
@@ -50,22 +49,77 @@ class TraceFrame(BaseModel):
     storage: Dict[HexBytes, HexBytes] = {}
     """Contract storage."""
 
+    contract_address: Optional[HexBytes] = None
+
     @validator("pc", "gas", "gas_cost", "depth", pre=True)
     def validate_ints(cls, value):
         return int(value, 16) if isinstance(value, str) else value
 
-    @cached_property
+    @property
     def address(self) -> Optional[HexBytes]:
         """
         The address of this CALL frame.
         Only returns a value if this frame's opcode is a call-based opcode.
         """
 
-        if self.op not in CALL_OPCODES or CallType.CREATE.value in self.op:
-            # CREATE address is handled elsewhere when creating CallTreeNode.
-            return None
+        if not self.contract_address and (
+            self.op in CALL_OPCODES and CallType.CREATE.value not in self.op
+        ):
+            self.contract_address = HexBytes(self.stack[-2][-20:])
 
-        return HexBytes(self.stack[-2][-20:])
+        return self.contract_address
+
+
+def create_trace_frames(data: Iterator[Dict]) -> Iterator[TraceFrame]:
+    """
+    Get trace frames from ``debug_traceTransaction`` response items.
+    Sets the ``contract_address`` for CREATE and CREATE2 frames by
+    looking ahead and finding it.
+
+    Args:
+        data (Iterator[Dict]): An iterator of response struct logs.
+
+    Returns:
+        Iterator[:class:`~evm_trace.geth.TraceFrame`]
+    """
+
+    # NOTE: Use a new iter in case a list or something is passed in.
+    # This logic requires an iterator.
+    frames = iter(data)
+
+    for frame in frames:
+        if CallType.CREATE.value in frame.get("op", ""):
+            # Before yielding, find the address of the CREATE.
+            call_frames = []
+            start_depth = frame.get("depth", 0)
+            for next_frame in frames:
+                depth = next_frame.get("depth", 0)
+                if depth == start_depth:
+                    # Extract the address for the original CREATE using
+                    # the first frame after the CREATE with an equal depth.
+                    stack = next_frame.get("stack", [])
+                    if len(stack) > 0:
+                        raw_addr = HexBytes(stack[-1][-40:])
+                        try:
+                            frame["contract_address"] = HexBytes(to_address(raw_addr))
+                        except Exception:
+                            # Potentially, a transaction was made with poor data.
+                            frame["contract_address"] = raw_addr
+
+                    # Yield the original CREATE frame with an address.
+                    yield TraceFrame(**frame)
+                    break
+
+                elif depth > start_depth:
+                    call_frames.append(next_frame)
+
+            # Yield all the CREATE's frames after the CREATE frame.
+            for call_frame in call_frames:
+                yield TraceFrame(**call_frame)
+
+        else:
+            # Every frame besides frames related to CREATE and CREATE2.
+            yield TraceFrame(**frame)
 
 
 def get_calltree_from_geth_call_trace(data: Dict) -> CallTreeNode:

--- a/evm_trace/geth.py
+++ b/evm_trace/geth.py
@@ -50,6 +50,7 @@ class TraceFrame(BaseModel):
     """Contract storage."""
 
     contract_address: Optional[HexBytes] = None
+    """The address producing the frame."""
 
     @validator("pc", "gas", "gas_cost", "depth", pre=True)
     def validate_ints(cls, value):

--- a/evm_trace/utils.py
+++ b/evm_trace/utils.py
@@ -1,6 +1,7 @@
 from eth_utils import to_checksum_address
+from hexbytes import HexBytes
 
 
 def to_address(value):
     # clear the padding and expand to 32 bytes
-    return to_checksum_address(value[-20:].rjust(20, b"\x00"))
+    return to_checksum_address(HexBytes(value)[-20:].rjust(20, b"\x00"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,5 +77,11 @@ def parity_create2_trace_list():
 
 
 @pytest.fixture
-def geth_create2_trace_frames():
-    return [TraceFrame(**x) for x in GETH_CREATE2_TRACE]
+def geth_create2_struct_logs():
+    return GETH_CREATE2_TRACE
+
+
+@pytest.fixture
+def geth_create2_trace_frames(geth_create2_struct_logs):
+    # NOTE: These frames won't have the CREATE address set.
+    return [TraceFrame(**x) for x in geth_create2_struct_logs]

--- a/tests/test_geth.py
+++ b/tests/test_geth.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 from evm_trace.enums import CallType
 from evm_trace.geth import (
     TraceFrame,
+    create_trace_frames,
     get_calltree_from_geth_call_trace,
     get_calltree_from_geth_trace,
 )
@@ -158,3 +159,15 @@ CALL: {address}.<{calldata[:10]}>
     create_node = node.calls[0]
     assert create_node.value == expected_value
     assert create_node.calldata.startswith(expected_calldata)
+
+
+def test_create_trace_frames_from_geth_create2_struct_logs(
+    geth_create2_struct_logs, geth_create2_trace_frames
+):
+    frames = list(create_trace_frames(geth_create2_struct_logs))
+    assert frames != geth_create2_trace_frames
+
+    assert "CREATE2" in [f.op for f in frames]
+    for frame in frames:
+        if frame.op == "CREATE2":
+            assert frame.address == HexBytes("0x7c23b43594428a657718713ff246c609eeddfaff")


### PR DESCRIPTION
### What I did

Adds a nice method for creating trace frames that handles the setting of CREATE2 addresses.
I think this is needed to find an annoying bug where source tracebacks are missing large chunks in the Ape framework.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
