### PR TITLE
fix: missing trace frames during creates

### DIFF
--- a/tests/test_geth.py
+++ b/tests/test_geth.py
@@ -165,6 +165,7 @@ def test_create_trace_frames_from_geth_create2_struct_logs(
     geth_create2_struct_logs, geth_create2_trace_frames
 ):
     frames = list(create_trace_frames(geth_create2_struct_logs))
+    assert len(frames) == len(geth_create2_trace_frames)
     assert frames != geth_create2_trace_frames
 
     assert "CREATE2" in [f.op for f in frames]


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: https://github.com/ApeWorX/ape/issues/1643

I am not sure, but `tee` doesn't copy the iterators right.. when you iterate through one, the other one is also iterated through, in some contexts, such as this one. maybe we are just using iterators wrong somewhere else in Ape but it makes tee kind of unreliable in general.

### How I did it

add test
notice it fails
replace tee with tracker approach
test now passes

### How to verify it

test now passes
also see linked issue

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
