### PR TITLE
chore: upgrade eth and other dependencies [APE-1615]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pydantic>=2.4.2,<3",
-        "py-evm>=0.7.0a3,<0.8",
+        "py-evm>=0.8.0b1,<0.9",
         "eth-utils>=2.1,<3",
         "msgspec>=0.8",
         "eth-pydantic-types>=0.1.0a4",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     install_requires=[
         "pydantic>=2.4.2,<3",
         "py-evm>=0.8.0b1,<0.9",
-        "eth-utils>=2.1,<3",
+        "eth-utils>=2.3.1,<3",
         "msgspec>=0.8",
         "eth-pydantic-types>=0.1.0a4",
     ],

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     url="https://github.com/ApeWorX/evm-trace",
     include_package_data=True,
     install_requires=[
-        "pydantic>=2.4.2,<3",
+        "pydantic>=2.5.2,<3",
         "py-evm>=0.8.0b1,<0.9",
         "eth-utils>=2.3.1,<3",
         "msgspec>=0.8",


### PR DESCRIPTION
### What I did

hoping for more proper python 3.10 and 3.11 support by upgrading eth..

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
