### PR TITLE
fix: lower eth pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pydantic>=2.5.2,<3",
-        "py-evm>=0.8.0b1,<0.9",
+        "py-evm>=0.7.0a4,<0.9",  # NOTE: We support both 0.7 and 0.8.
         "eth-utils>=2.3.1,<3",
         "msgspec>=0.8",
         "eth-pydantic-types>=0.1.0a5",


### PR DESCRIPTION
### What I did

We are able to do this to fix insalling with web3.py and ape rn
There is difference in the peer deps or the stuff we import in either version so it's fine.

### How I did it

increase range

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
