### PR TITLE
chore: prep for 3.13 by removing msgspec dep

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [3.9, "3.10", "3.11", "3.12"]
+                python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
 
         steps:
         - uses: actions/checkout@v4

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -1,192 +1,195 @@
-from __future__ import annotations
+import sys
 
-from collections.abc import Iterator
-from typing import Any
+if sys.version_info < (3, 13):
+    from __future__ import annotations
 
-from eth.vm.memory import Memory
-from eth.vm.stack import Stack
-from eth_pydantic_types import Address, HexBytes
-from eth_utils import to_int
-from msgspec import Struct
-from msgspec.json import Decoder
+    from collections.abc import Iterator
+    from typing import Any
 
-# opcodes grouped by the number of items they pop from the stack
-# fmt: off
-POP_OPCODES = {
-    1: ["EXTCODEHASH", "ISZERO", "NOT", "BALANCE", "CALLDATALOAD", "EXTCODESIZE", "BLOCKHASH", "POP", "MLOAD", "SLOAD", "JUMP", "SELFDESTRUCT"],  # noqa: E501
-    2: ["SHL", "SHR", "SAR", "REVERT", "ADD", "MUL", "SUB", "DIV", "SDIV", "MOD", "SMOD", "EXP", "SIGNEXTEND", "LT", "GT", "SLT", "SGT", "EQ", "AND", "XOR", "OR", "BYTE", "SHA3", "KECCAK256", "MSTORE", "MSTORE8", "SSTORE", "JUMPI", "RETURN"],  # noqa: E501
-    3: ["RETURNDATACOPY", "ADDMOD", "MULMOD", "CALLDATACOPY", "CODECOPY", "CREATE"],
-    4: ["CREATE2", "EXTCODECOPY"],
-    6: ["STATICCALL", "DELEGATECALL"],
-    7: ["CALL", "CALLCODE"]
-}
-# fmt: on
-POPCODES = {op: n for n, opcodes in POP_OPCODES.items() for op in opcodes}
-POPCODES.update({f"LOG{n}": n + 2 for n in range(0, 5)})
-POPCODES.update({f"SWAP{i}": i + 1 for i in range(1, 17)})
-POPCODES.update({f"DUP{i}": i for i in range(1, 17)})
+    from eth.vm.memory import Memory
+    from eth.vm.stack import Stack
+    from eth_pydantic_types import Address, HexBytes
+    from eth_utils import to_int
+    from msgspec import Struct
+    from msgspec.json import Decoder
 
-
-class uint256(int):
-    pass
-
-
-class VMTrace(Struct):
-    code: HexBytes
-    """The code to be executed."""
-    ops: list[VMOperation]
-    """The operations executed."""
+    # opcodes grouped by the number of items they pop from the stack
+    # fmt: off
+    POP_OPCODES = {
+        1: ["EXTCODEHASH", "ISZERO", "NOT", "BALANCE", "CALLDATALOAD", "EXTCODESIZE", "BLOCKHASH", "POP", "MLOAD", "SLOAD", "JUMP", "SELFDESTRUCT"],  # noqa: E501
+        2: ["SHL", "SHR", "SAR", "REVERT", "ADD", "MUL", "SUB", "DIV", "SDIV", "MOD", "SMOD", "EXP", "SIGNEXTEND", "LT", "GT", "SLT", "SGT", "EQ", "AND", "XOR", "OR", "BYTE", "SHA3", "KECCAK256", "MSTORE", "MSTORE8", "SSTORE", "JUMPI", "RETURN"],  # noqa: E501
+        3: ["RETURNDATACOPY", "ADDMOD", "MULMOD", "CALLDATACOPY", "CODECOPY", "CREATE"],
+        4: ["CREATE2", "EXTCODECOPY"],
+        6: ["STATICCALL", "DELEGATECALL"],
+        7: ["CALL", "CALLCODE"]
+    }
+    # fmt: on
+    POPCODES = {op: n for n, opcodes in POP_OPCODES.items() for op in opcodes}
+    POPCODES.update({f"LOG{n}": n + 2 for n in range(0, 5)})
+    POPCODES.update({f"SWAP{i}": i + 1 for i in range(1, 17)})
+    POPCODES.update({f"DUP{i}": i for i in range(1, 17)})
 
 
-class VMOperation(Struct):
-    pc: int
-    """The program counter."""
-    cost: int
-    """The gas cost for this instruction."""
-    ex: VMExecutedOperation | None
-    """Information concerning the execution of the operation."""
-    sub: VMTrace | None
-    """Subordinate trace of the CALL/CREATE if applicable."""
-    op: str
-    """Opcode that is being called."""
-    idx: str
-    """Index in the tree."""
+    class uint256(int):
+        pass
 
 
-class VMExecutedOperation(Struct):
-    used: int
-    """The amount of remaining gas."""
-    push: list[HexBytes]
-    """The stack item placed, if any."""
-    mem: MemoryDiff | None
-    """If altered, the memory delta."""
-    store: StorageDiff | None
-    """The altered storage value, if any."""
+    class VMTrace(Struct):
+        code: HexBytes
+        """The code to be executed."""
+        ops: list[VMOperation]
+        """The operations executed."""
 
 
-class MemoryDiff(Struct):
-    off: int
-    """Offset into memory the change begins."""
-    data: HexBytes
-    """The changed data."""
+    class VMOperation(Struct):
+        pc: int
+        """The program counter."""
+        cost: int
+        """The gas cost for this instruction."""
+        ex: VMExecutedOperation | None
+        """Information concerning the execution of the operation."""
+        sub: VMTrace | None
+        """Subordinate trace of the CALL/CREATE if applicable."""
+        op: str
+        """Opcode that is being called."""
+        idx: str
+        """Index in the tree."""
 
 
-class StorageDiff(Struct):
-    key: uint256
-    """Which key in storage is changed."""
-    val: uint256
-    """What the value has been changed to."""
+    class VMExecutedOperation(Struct):
+        used: int
+        """The amount of remaining gas."""
+        push: list[HexBytes]
+        """The stack item placed, if any."""
+        mem: MemoryDiff | None
+        """If altered, the memory delta."""
+        store: StorageDiff | None
+        """The altered storage value, if any."""
 
 
-class VMTraceFrame(Struct):
-    """
-    A synthetic trace frame representing the state at a step of execution.
-    """
-
-    address: str
-    pc: int
-    op: str
-    depth: int
-    stack: list[int]
-    memory: bytes | memoryview
-    storage: dict[int, int]
+    class MemoryDiff(Struct):
+        off: int
+        """Offset into memory the change begins."""
+        data: HexBytes
+        """The changed data."""
 
 
-def to_trace_frames(
-    trace: VMTrace,
-    depth: int = 1,
-    address: str = "",
-    copy_memory: bool = True,
-) -> Iterator[VMTraceFrame]:
-    """
-    Replays a VMTrace and yields trace frames at each step of the execution.
-    Can be used as a much faster drop-in replacement for Geth-style traces.
+    class StorageDiff(Struct):
+        key: uint256
+        """Which key in storage is changed."""
+        val: uint256
+        """What the value has been changed to."""
 
-    Args:
-        trace (VMTrace): A decoded trace from a `trace_` rpc.
-        depth (int): A depth of the call being processed. automatically populated.
-        address (str): The address of the contract being executed. auto populated
-            except the root call.
-        copy_memory (bool): Whether to copy memory when returning trace frames.
-            Disable for a speedup when dealing with traces using a large amount of memory.
-            when disabled, `VMTraceFrame.memory` becomes `memoryview` instead of `bytes`, which
-            works like a pointer at the memory `bytearray`. this means you must process the
-            frames immediately, otherwise you risk memory value mutating further into execution.
 
-    Returns:
-        Iterator[VMTraceFrame]: An iterator of synthetic traces which can be used as a drop-in
-        replacement for Geth-style traces. also contains the address of the current contract
-        context.
-    """
-    memory = Memory()
-    stack = Stack()
-    storage: dict[int, int] = {}
-    call_address = ""
-    read_memory = memory.read_bytes if copy_memory else memory.read
+    class VMTraceFrame(Struct):
+        """
+        A synthetic trace frame representing the state at a step of execution.
+        """
 
-    for op in trace.ops:
-        if op.ex and op.ex.mem:
-            memory.extend(op.ex.mem.off, len(op.ex.mem.data))
+        address: str
+        pc: int
+        op: str
+        depth: int
+        stack: list[int]
+        memory: bytes | memoryview
+        storage: dict[int, int]
 
-        # geth convention is to return after memory expansion, but before the operation is applied
-        yield VMTraceFrame(
-            address=address,
-            pc=op.pc,
-            op=op.op,
-            depth=depth,
-            stack=[to_int(val) for val in stack.values],
-            memory=read_memory(0, len(memory)),
-            storage=storage.copy(),
-        )
 
-        if op.op in ["CALL", "DELEGATECALL", "STATICCALL"]:
-            call_address = Address.__eth_pydantic_validate__(stack.values[-2])
+    def to_trace_frames(
+        trace: VMTrace,
+        depth: int = 1,
+        address: str = "",
+        copy_memory: bool = True,
+    ) -> Iterator[VMTraceFrame]:
+        """
+        Replays a VMTrace and yields trace frames at each step of the execution.
+        Can be used as a much faster drop-in replacement for Geth-style traces.
 
-        if op.ex:
-            if op.ex.mem:
-                memory.write(op.ex.mem.off, len(op.ex.mem.data), op.ex.mem.data)
+        Args:
+            trace (VMTrace): A decoded trace from a `trace_` rpc.
+            depth (int): A depth of the call being processed. automatically populated.
+            address (str): The address of the contract being executed. auto populated
+                except the root call.
+            copy_memory (bool): Whether to copy memory when returning trace frames.
+                Disable for a speedup when dealing with traces using a large amount of memory.
+                when disabled, `VMTraceFrame.memory` becomes `memoryview` instead of `bytes`, which
+                works like a pointer at the memory `bytearray`. this means you must process the
+                frames immediately, otherwise you risk memory value mutating further into execution.
 
-            num_pop = POPCODES.get(op.op)
-            if num_pop:
-                stack.pop_any(num_pop)
+        Returns:
+            Iterator[VMTraceFrame]: An iterator of synthetic traces which can be used as a drop-in
+            replacement for Geth-style traces. also contains the address of the current contract
+            context.
+        """
+        memory = Memory()
+        stack = Stack()
+        storage: dict[int, int] = {}
+        call_address = ""
+        read_memory = memory.read_bytes if copy_memory else memory.read
 
-            for item in op.ex.push:
-                stack.push_bytes(item)
+        for op in trace.ops:
+            if op.ex and op.ex.mem:
+                memory.extend(op.ex.mem.off, len(op.ex.mem.data))
 
-            # erigon bug: https://github.com/ledgerwatch/erigon/pull/7970
-            if op.op == "PUSH0" and not op.ex.push:
-                stack.push_int(0)
-
-            if op.ex.store:
-                storage[op.ex.store.key] = op.ex.store.val
-
-        if op.sub:
-            yield from to_trace_frames(
-                op.sub, depth=depth + 1, address=call_address, copy_memory=copy_memory
+            # geth convention is to return after memory expansion, but before the operation is applied
+            yield VMTraceFrame(
+                address=address,
+                pc=op.pc,
+                op=op.op,
+                depth=depth,
+                stack=[to_int(val) for val in stack.values],
+                memory=read_memory(0, len(memory)),
+                storage=storage.copy(),
             )
 
+            if op.op in ["CALL", "DELEGATECALL", "STATICCALL"]:
+                call_address = Address.__eth_pydantic_validate__(stack.values[-2])
 
-class RPCResponse(Struct):
-    result: RPCTraceResult | list[RPCTraceResult]
+            if op.ex:
+                if op.ex.mem:
+                    memory.write(op.ex.mem.off, len(op.ex.mem.data), op.ex.mem.data)
+
+                num_pop = POPCODES.get(op.op)
+                if num_pop:
+                    stack.pop_any(num_pop)
+
+                for item in op.ex.push:
+                    stack.push_bytes(item)
+
+                # erigon bug: https://github.com/ledgerwatch/erigon/pull/7970
+                if op.op == "PUSH0" and not op.ex.push:
+                    stack.push_int(0)
+
+                if op.ex.store:
+                    storage[op.ex.store.key] = op.ex.store.val
+
+            if op.sub:
+                yield from to_trace_frames(
+                    op.sub, depth=depth + 1, address=call_address, copy_memory=copy_memory
+                )
 
 
-class RPCTraceResult(Struct):
-    trace: list | None
-    vmTrace: VMTrace
-    stateDiff: dict | None
+    class RPCResponse(Struct):
+        result: RPCTraceResult | list[RPCTraceResult]
 
 
-def dec_hook(type: type, obj: Any) -> Any:
-    if type is uint256:
-        return uint256(obj, 16)
-    elif type is HexBytes:
-        return HexBytes(obj)
+    class RPCTraceResult(Struct):
+        trace: list | None
+        vmTrace: VMTrace
+        stateDiff: dict | None
 
 
-def from_rpc_response(buffer: bytes) -> VMTrace | list[VMTrace]:
-    """
-    Decode structured data from a raw `trace_replayTransaction` or `trace_replayBlockTransactions`.
-    """
-    response = Decoder(RPCResponse, dec_hook=dec_hook).decode(buffer)
-    result: list[RPCTraceResult] | RPCTraceResult = response.result
-    return [i.vmTrace for i in result] if isinstance(result, list) else result.vmTrace
+    def dec_hook(type: type, obj: Any) -> Any:
+        if type is uint256:
+            return uint256(obj, 16)
+        elif type is HexBytes:
+            return HexBytes(obj)
+
+
+    def from_rpc_response(buffer: bytes) -> VMTrace | list[VMTrace]:
+        """
+        Decode structured data from a raw `trace_replayTransaction` or `trace_replayBlockTransactions`.
+        """
+        response = Decoder(RPCResponse, dec_hook=dec_hook).decode(buffer)
+        result: list[RPCTraceResult] | RPCTraceResult = response.result
+        return [i.vmTrace for i in result] if isinstance(result, list) else result.vmTrace

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -29,17 +29,14 @@ if sys.version_info < (3, 13):
     POPCODES.update({f"SWAP{i}": i + 1 for i in range(1, 17)})
     POPCODES.update({f"DUP{i}": i for i in range(1, 17)})
 
-
     class uint256(int):
         pass
-
 
     class VMTrace(Struct):
         code: HexBytes
         """The code to be executed."""
         ops: list[VMOperation]
         """The operations executed."""
-
 
     class VMOperation(Struct):
         pc: int
@@ -55,7 +52,6 @@ if sys.version_info < (3, 13):
         idx: str
         """Index in the tree."""
 
-
     class VMExecutedOperation(Struct):
         used: int
         """The amount of remaining gas."""
@@ -66,20 +62,17 @@ if sys.version_info < (3, 13):
         store: StorageDiff | None
         """The altered storage value, if any."""
 
-
     class MemoryDiff(Struct):
         off: int
         """Offset into memory the change begins."""
         data: HexBytes
         """The changed data."""
 
-
     class StorageDiff(Struct):
         key: uint256
         """Which key in storage is changed."""
         val: uint256
         """What the value has been changed to."""
-
 
     class VMTraceFrame(Struct):
         """
@@ -93,7 +86,6 @@ if sys.version_info < (3, 13):
         stack: list[int]
         memory: bytes | memoryview
         storage: dict[int, int]
-
 
     def to_trace_frames(
         trace: VMTrace,
@@ -168,23 +160,19 @@ if sys.version_info < (3, 13):
                     op.sub, depth=depth + 1, address=call_address, copy_memory=copy_memory
                 )
 
-
     class RPCResponse(Struct):
         result: RPCTraceResult | list[RPCTraceResult]
-
 
     class RPCTraceResult(Struct):
         trace: list | None
         vmTrace: VMTrace
         stateDiff: dict | None
 
-
     def dec_hook(type: type, obj: Any) -> Any:
         if type is uint256:
             return uint256(obj, 16)
         elif type is HexBytes:
             return HexBytes(obj)
-
 
     def from_rpc_response(buffer: bytes) -> VMTrace | list[VMTrace]:
         """

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -123,7 +123,7 @@ if sys.version_info < (3, 13):
             if op.ex and op.ex.mem:
                 memory.extend(op.ex.mem.off, len(op.ex.mem.data))
 
-            # geth convention is to return after memory expansion, but before the operation is applied
+            # geth convention is to return after memory expansion, but before operation is applied
             yield VMTraceFrame(
                 address=address,
                 pc=op.pc,
@@ -176,7 +176,7 @@ if sys.version_info < (3, 13):
 
     def from_rpc_response(buffer: bytes) -> VMTrace | list[VMTrace]:
         """
-        Decode structured data from a raw `trace_replayTransaction` or `trace_replayBlockTransactions`.
+        Decode structured data from raw `trace_replayTransaction` or `trace_replayBlockTransactions`
         """
         response = Decoder(RPCResponse, dec_hook=dec_hook).decode(buffer)
         result: list[RPCTraceResult] | RPCTraceResult = response.result

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import sys
 
 if sys.version_info < (3, 13):
-    from __future__ import annotations
 
     from collections.abc import Iterator
     from typing import Any
@@ -176,7 +177,8 @@ if sys.version_info < (3, 13):
 
     def from_rpc_response(buffer: bytes) -> VMTrace | list[VMTrace]:
         """
-        Decode structured data from raw `trace_replayTransaction` or `trace_replayBlockTransactions`
+        Decode structured data from a raw `trace_replayTransaction` or
+        `trace_replayBlockTransactions`.
         """
         response = Decoder(RPCResponse, dec_hook=dec_hook).decode(buffer)
         result: list[RPCTraceResult] | RPCTraceResult = response.result

--- a/evm_trace/vmtrace.py
+++ b/evm_trace/vmtrace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 
+# msgspec does not currently build on python 3.13 so hide it behind a version check
 if sys.version_info < (3, 13):
 
     from collections.abc import Iterator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
+requires = ["setuptools>=75.6.0", "wheel", "setuptools_scm[toml]>=5.0"]
 
 [tool.mypy]
 exclude = "build/"

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "pydantic>=2.5.2,<3",
         "py-evm>=0.10.1b1,<0.11",
         "eth-utils>=2.3.1,<6",
-        "msgspec>=0.8",
+        "msgspec>=0.8; python_version < '3.13'",
         "eth-pydantic-types>=0.1.3,<0.2",
     ],
     python_requires=">=3.9,<4",
@@ -86,5 +86,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
         "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml
     ],
     "release": [  # `release` GitHub Action job uses this
-        "setuptools",  # Installation tool
+        "setuptools>=75.6.0",  # Installation tool
         "wheel",  # Packaging tool
         "twine",  # Package upload tool
     ],


### PR DESCRIPTION

### What I did

Prep for 3.13 by removing msgspec dep and functionality when using it.

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
