### PR TITLE
fix(deps): widen pin on py-evm as it causes issues w/ web3 v7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "eth-utils>=2.3.1,<6",
         "msgspec>=0.8",
         "pydantic>=2.5.2,<3",
-        "py-evm>=0.10.1b1,<0.11",
+        "py-evm>=0.10.1b1,<0.13",
     ],
     python_requires=">=3.9,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

Notice there was a really annoying issue where we could not install web3 v7 because of a pinning issue between this lib and eth-tester (which is in `web3[tester]` extra)
### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
